### PR TITLE
Update serviceslugs.txt

### DIFF
--- a/serviceslugs.txt
+++ b/serviceslugs.txt
@@ -17,7 +17,6 @@ spotify
 amazon
 bitcoin
 paypal
-podnews
 twitter
 mastodon
 slack


### PR DESCRIPTION
Podnews will never set its own slug.

For documentation purposes...

Podnews URIs are:
```
podnews.net/podcast/[:itunesid]
podnews.net/podcast/pi[:podcastindexid]
podnews.net/podcast/[:spotifyshowid]
```
These currently canonically link to the iTunes ID and will redirect there. I plan to switch at some point to canonically link to Podcast Index IDs.