### PR TITLE
Added Podchaser to serviceslugs.txt

### DIFF
--- a/serviceslugs.txt
+++ b/serviceslugs.txt
@@ -43,3 +43,4 @@ shoutengine
 pinecast
 podomatic
 zencast
+podchaser


### PR DESCRIPTION
Podchaser can be linked to based on iTunes IDs and RSS feed URLs currently, but of course the direct ID will always be more efficient and accurate.