### PR TITLE
<podcast:chapter> Start Time Type Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ this larger namespace.  But, we don't want to be so general that the spec become
    mime type is.  In that scenario, time codes are assumed to be present in the file in some capacity.
 
 
-- **\<podcast:chapter start="[Normal Play Time]" title="[(string)]" href="[uri to content]" type="[mime type]"/>**
+- **\<podcast:chapter start="[(int)]" title="[(string)]" href="[uri to content]" type="[mime type]"/>**
 
    Item
 
    (optional | multiple)
 
    This element specifies a point in time during the podcast that can be linked to directly and optionally supplemented with additional content.
-   `start` is required and uses the [Normal Play Time](https://www.w3.org/TR/media-frags/#naming-time) standard.
+   `start` is required to identify the starting point of the chapter within the podcast. Start time is expressed as seconds since the start time of the podcast.
    `title` is optional and is used as a user facing identifier for this chapter
    `href` is optional and points to additional user facing content
    `type` is optional but it is strongly encouraged if `href` is used so that clients can handle the chapter content appropriately


### PR DESCRIPTION
At @tomrossi7 's recommendation I'm proposing a change from using the lesser known [Normal Play Time](https://www.ietf.org/rfc/rfc2326.txt) type to use seconds since the start of podcast instead represented in integers. This is a simpler way of representing a time within a podcast and will be simpler for clients to adopt.

This also aligns with the type used by the itunes tag: `<itunes:duration>`