### PR TITLE
Fix chapters example link

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -34,7 +34,7 @@ This tag is used to link to a transcript or closed captions file. Multiple tags 
 
 `<podcast:transcript url="https://example.com/episode1/transcript.json" type="application/json" language="es" rel="captions" />`
 
-Detailed file format information and example files are [here](transcripts/transcripts.md).
+Detailed file format information and example files are [here](../transcripts/transcripts.md).
 
 <br><br>
 


### PR DESCRIPTION
The link to examples of chapters was 404ing.