### PR TITLE
Change namespace URI

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -2,8 +2,12 @@
 
 A wholistic RSS namespace for podcasting that is meant to synthesize the fragmented world of podcast namespaces. As elements are canonized, they will be added to this document so developers can begin implementation. The specifications below are considered locked and the team will prioritize backward compatibility. We are operating under the [Rules for Standards-Makers](http://scripting.com/2017/05/09/rulesForStandardsmakers.html).
 
-If your application generates RSS feeds and you implement one or more elements below, you will need to link this DTD in your XML.
-`<rss version="2.0" xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md">`
+The namespace for this extension is `http://podcastindex.net/namespace/1.0`. Clients which recognize this namespace must also recognize `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md` as identical. The suggested tag prefix for use in XML is `podcast`, but clients should support alternate prefixes for this namespace. If your application generates RSS feeds and you implement one or more elements below, you will need to link this DTD in your XML:
+
+```
+<rss version="2.0" xmlns:podcast="http://podcastindex.net/namespace/1.0">
+```
+
 # Podcast Tags
 Each tag below exists in the podcast namespace within the specified parent. All attributes are required unless explicitly specified as optional.
 

--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -2,7 +2,7 @@
 
 A wholistic RSS namespace for podcasting that is meant to synthesize the fragmented world of podcast namespaces. As elements are canonized, they will be added to this document so developers can begin implementation. The specifications below are considered locked and the team will prioritize backward compatibility. We are operating under the [Rules for Standards-Makers](http://scripting.com/2017/05/09/rulesForStandardsmakers.html).
 
-The namespace for this extension is `http://podcastindex.net/namespace/1.0`. Clients which recognize this namespace must also recognize `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md` as identical. The suggested tag prefix for use in XML is `podcast`, but clients should support alternate prefixes for this namespace. If your application generates RSS feeds and you implement one or more elements below, you will need to link this DTD in your XML:
+The namespace for this extension is `https://podcastindex.org/namespace/1.0`. Clients which recognize this namespace must also recognize `https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md` as identical. The suggested tag prefix for use in XML is `podcast`, but clients should support alternate prefixes for this namespace. If your application generates RSS feeds and you implement one or more elements below, you will need to link this DTD in your XML:
 
 ```
 <rss version="2.0" xmlns:podcast="http://podcastindex.net/namespace/1.0">


### PR DESCRIPTION
This changes the XML namespace to `https://podcastindex.org/namespace/1.0` while retaining backwards compatibility to the old namespace. It also provides guidance regarding the XML prefix for the namespace's tags while reminding implementers that they should respect alternate prefixes for the same namespace URI.

Resolves #113.