### PR TITLE
Add podcloud to Podcast Slug

### DIFF
--- a/serviceslugs.txt
+++ b/serviceslugs.txt
@@ -26,6 +26,7 @@ podcastaddict
 podcastindex
 podcasts.com
 podchaser
+podcloud
 podfriend
 podiant
 podigee


### PR DESCRIPTION
Hello!
Podcloud is a host and a catalog of podcast used a lot by french (an more) independant community

https://podcloud.fr/