### PR TITLE
Change "application/srt" to "text/srt" to be consistent with Examples.

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -29,7 +29,7 @@ Multiple
 #### Attributes
  - **url:** URL of the podcast transcript.
 
- - **type:** Mime type of the file such as `text/plain`, `text/html`, `application/srt`, `application/json`
+ - **type:** Mime type of the file such as `text/plain`, `text/html`, `text/srt`, `application/json`
 
  - **language (optional):** The language of the linked transcript. If there is no language attribute given, the linked file is assumed to be the same language that is specified by the RSS `<language>` element.
 


### PR DESCRIPTION
Looking through here: https://www.iana.org/assignments/media-types/media-types.xhtml#text there’s no specific type for SRT, but there is for text/vtt and text/vnd.dvb.subtitle so I think we should ammend the PC2.0 docs: https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md Currently says: "type: Mime type of the file such as text/plain, text/html, application/srt, application/json” but application/srt should be text/srt I think.