### PR TITLE
Clarify payment interval

### DIFF
--- a/value/value.md
+++ b/value/value.md
@@ -41,6 +41,8 @@ in a single transaction.  Likewise, some apps with limited connectivity may need
 hour.  In that scenario, there would be 60 payments added up into a single, larger payment.  Batching transactions
 like this also helps to minimize the impact of transaction fees on the underlying cryptocurrency network.
 
+Note that playback speed is not a factor in this calculation. The "one minute payment interval" refers to the minutes that make up the total runtime of the content, thus all payment calculations are independent of playback speed.
+
 <div class="page"/>
 
 <br><br>


### PR DESCRIPTION
Resolves #200.

Makes it clear that payment speed is irrelevant for the payment interval and thus for the payment calculation.

This is also how apps have implemented payment intervals. See the relevant code snippets linked below:
* Breez: [podcast_payments_bloc.dart#L180](https://github.com/breez/breezmobile/blob/23c8e9ec26f2639c01aca1fbb78e8c3e0e001112/lib/bloc/podcast_payments/podcast_payments_bloc.dart#L180)
* Sphinx: [pod/index.tsx#L205](https://github.com/stakwork/sphinx-android/blob/72c54c56c75b1deebf0143890692adf682100763/src/components/chat/pod/index.tsx#L205)
