### PR TITLE
Update Lightning example to use `float` instead of `int`

### DIFF
--- a/value/value.md
+++ b/value/value.md
@@ -96,8 +96,7 @@ to be streamed to what is, essentially, an open invoice.  Other cryptocurrencies
 would be used here.  If not, a value of "default" should be given.
 
 The "suggested" amount is just that.  It's a suggestion, and must be changeable by the user to another value, or
-to zero.  The suggested amount should always be given in the smallest denomination available within the payment
-protocol being used.  For instance, with Lightning it is given in millisatoshis.
+to zero.  The suggested amount depends on the payment protocol being used.  For instance, with Lightning on the Bitcoin network, the amount can be as low as one millisatoshi, expressed as `0.00000000001` BTC.
 
 A single value tag can contain many `<podcast:valueRecipient>` tags as children.  All of these given recipients are
 sent individual payments when the payment interval triggers.


### PR DESCRIPTION
Resolves #228

Suggest value was changed from `int` to `float` in #230, but the example in the text was not updated. I reworded the sentence a bit and updated the example to make things more clear.

