### PR TITLE
Fix it's vs. its in docs

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -252,7 +252,7 @@ Single
 The node value is a decimal number.  It is required.
 
 #### Attributes
- - **display:** (optional) - If this attribute is present, podcast apps and aggregators are encouraged to show it's value instead of the purely numerical node value.  This attribute is a string.
+ - **display:** (optional) - If this attribute is present, podcast apps and aggregators are encouraged to show its value instead of the purely numerical node value.  This attribute is a string.
 
 The episode numbers are decimal, so numbering such as `100.5` is acceptable if there was a special mini-episode published between two other episodes.  In that scenario, the number would help with proper chronological sorting, while the `display` attribute could specify an alternate special "number" (a moniker) to display for the episode in a podcast player app UI.
 
@@ -291,7 +291,7 @@ The node value is a string, which is the title of the trailer. It is required.
  - **type:** (recommended) The mime type of the file. This attribute is a string.
  - **season:** (optional) If this attribute is present it specifies that this trailer is for a particular season number. This attribute is a number.
 
-If there is more than one trailer tag present in the channel, the most recent one (according to it's `pubdate`) should be chosen as the preview by default within podcast apps.  If the `season` attribute is present, it must
+If there is more than one trailer tag present in the channel, the most recent one (according to its `pubdate`) should be chosen as the preview by default within podcast apps.  If the `season` attribute is present, it must
 be a number that matches the format of the `<podcast:season>` tag.  So, for a podcast that has 3 published seasons, a new `<podcast:trailer season="4">` tag can be put in the channel to later be matched up with a `<podcast:season>4<podcast:season>`
 tag when it is published within a new `<item>`.
 
@@ -476,8 +476,8 @@ This element is used to declare a unique, global identifier for a podcast. The v
 which has a UUID of `ead4c236-bf58-58c6-a2c6-a6b28d128cb6`. Tools like [this one](https://www.uuidtools.com/v5) can help generate these values by hand. Or, language libraries like [this one](https://github.com/sporkmonger/uuidtools) in Ruby are widely
 available.
 
-A podcast gets assigned a podcast:guid once in it's lifetime using it's current feed url (at the time of assignment) as the seed value. That GUID is then meant to follow the podcast from then on, for the duration of it's life, even if the feed url
-changes. This means that when a podcast moves from one hosting platform to another, it's podcast:guid should be discovered by the new host and imported into the new platform for inclusion into the feed.
+A podcast gets assigned a podcast:guid once in its lifetime using its current feed url (at the time of assignment) as the seed value. That GUID is then meant to follow the podcast from then on, for the duration of its life, even if the feed url
+changes. This means that when a podcast moves from one hosting platform to another, its podcast:guid should be discovered by the new host and imported into the new platform for inclusion into the feed.
 
 Using this pattern, podcasts can maintain a consistent identity across the open RSS ecosystem without a central authority.
 


### PR DESCRIPTION
Replaced several instances of "it's" with "its" in docs (https://www.grammarly.com/blog/its-vs-its/)