### PR TITLE
Update value example and description to include AMP

### DIFF
--- a/value/value.md
+++ b/value/value.md
@@ -265,12 +265,12 @@ API that exposes a compatible process.
 
 Currently, development is centered fully on [Lightning](https://github.com/lightningnetwork) using the "keysend" protocol.  Keysend allows for push
 based payments without the recipient needing to generate an invoice to receive them.
+Another method to send spontaneous payments via Lightning is AMP, atomic
+[multipath payments][AMP]. AMP supersedes keysend in many ways and allows for
+more robust and larger payments. However, it is still in beta and thus not
+widely  implemented as of now.
 
-Atomic multipath payments ([AMPs]) are another, more modern method to send
-spontaneous payments via lightning. AMP payments require the same information
-as `keysend` payments, namely a node pubkey and a payment amount.
-
-[AMPs]: https://bitcoinops.org/en/topics/multipath-payments/
+[AMP]: https://bitcoinops.org/en/topics/multipath-payments/
 
 <br>
 

--- a/value/value.md
+++ b/value/value.md
@@ -266,6 +266,12 @@ API that exposes a compatible process.
 Currently, development is centered fully on [Lightning](https://github.com/lightningnetwork) using the "keysend" protocol.  Keysend allows for push
 based payments without the recipient needing to generate an invoice to receive them.
 
+Atomic multipath payments ([AMPs]) are another, more modern method to send
+spontaneous payments via lightning. AMP payments require the same information
+as `keysend` payments, namely a node pubkey and a payment amount.
+
+[AMPs]: https://bitcoinops.org/en/topics/multipath-payments/
+
 <br>
 
 #### Lightning

--- a/value/value.md
+++ b/value/value.md
@@ -279,7 +279,7 @@ as `keysend` payments, namely a node pubkey and a payment amount.
 For the `<podcast:value>` tag, the following attributes MUST be used:
 
  - `type` (required): "lightning"
- - `method` (required): "keysend"
+ - `method` (required): "keysend" or "amp"
  - `suggested` (optional): A float representing a BTC amount.
         e.g. 0.00000005000 is 5 Sats.
 
@@ -293,7 +293,7 @@ If the receiving Lightning node, or service, requires a custom record or meta-da
 the `customKey` and `customValue` can be utilized as follows:
 
  - `type`: "node"
- - `method`: "keysend"
+ - `method`: "keysend" or "amp"
  - `customKey`: \<key name\>
  - `customValue`: \<value\>
  - `address`: \<the destination node's pubkey\>

--- a/value/value.md
+++ b/value/value.md
@@ -263,12 +263,12 @@ they will spend and charge.
 The value block is designed to be flexible enough to handle most any cryptocurrency, and even fiat currencies with a given
 API that exposes a compatible process.
 
-Currently, development is centered fully on [Lightning](https://github.com/lightningnetwork) using the "keysend" protocol.  Keysend allows for push
+Currently, development is centered mostly on [Lightning](https://github.com/lightningnetwork) using the "keysend" method.  Keysend allows for push
 based payments without the recipient needing to generate an invoice to receive them.
 Another method to send spontaneous payments via Lightning is AMP, atomic
 [multipath payments][AMP]. AMP supersedes keysend in many ways and allows for
 more robust and larger payments. However, it is still in beta and thus not
-widely  implemented as of now.
+widely implemented as of now.
 
 [AMP]: https://bitcoinops.org/en/topics/multipath-payments/
 

--- a/value/value.md
+++ b/value/value.md
@@ -345,6 +345,18 @@ Since the value block is defined at the `<channel>` level, it applies to every p
 </channel>
 ```
 
+To use Atomic Multipath Payments (AMP) instead of `keysend`, simply set the
+payment `method` to `amp`:
+
+```xml
+...
+<channel>
+  <podcast:value type="lightning" method="amp" suggested="0.00000015000">
+  ...
+  </podcast:value>
+</channel>
+```
+
 ##### Example: `<Item>` Override
 
 To set up different payment splits for individual episodes, a value block has to

--- a/value/valueslugs.txt
+++ b/value/valueslugs.txt
@@ -1,5 +1,6 @@
 bitcoin
 lightning
 keysend
+amp
 wallet
 node


### PR DESCRIPTION
To quote from the [lnd 0.13-beta announcement](https://lightning.engineering/posts/2021-06-17-lnd-v0.13/):

> AMP is the successor to the widely used “keysend” protocol as it enables payments to be sent in multiple shards similar to Multi-Path Payments (MPP). Unlike MPP, the receiver cannot pull the payment until all the payment shards arrive. This trait makes the new payment type more useful for payment-splitting aware probing.

Nothing in the specification has to change to support AMP. Just specify `amp` as the `method` instead of `keysend`.

To quote from the announcement again:

> Sending a spontaneous AMP payment requires specifying the amount and pubkey of the destination

I have linked to [Multipath Payments](https://bitcoinops.org/en/topics/multipath-payments/) page of Bitcoin Optech. It includes all relevant information.

---

Additional resources on AMP that might be useful:

* https://wiki.ion.radar.tech/tech/research/atomic-multi-path-payments
* https://bitcoin.stackexchange.com/a/89476


