### PR TITLE
Update 1.0.md

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -505,3 +505,17 @@ Example GUID for feed url `podnews.net/rss`:
 ```xml
 <podcast:guid>9b024349-ccf0-5f69-a609-6b82873eab3c</podcast:guid>
 ```
+
+### Guid-enabled fast-follow share links
+The `podcast:guid` value above enables podcasters to produce a link that can share a podcast on a variety of different platforms.
+
+The format of the link is `https://(a podcast website link)#fastfollow-(type):(a podcast guid)`
+
+`type` is currently `podcast`, but may be extended in future.
+
+A working example is https://podnews.net/podcast/i8xe9/listen#fastfollow-podcast:9b024349-ccf0-5f69-a609-6b82873eab3c or the QR code given below.
+![podnews-qr](https://user-images.githubusercontent.com/231941/127796108-d819de43-6c0e-4c7b-9579-ed1f19989443.png)
+
+When scanned on a mobile phone's camera app, this link will go to the specified podcast website. Behavior of this website is up to the creator: some may use a default homepage, others may sniff the useragent and open a default podcast app on a device. In the working example, above, an iPhone user may be taken to Apple Podcasts; an Android user may be taken to Google Podcasts; and another device will be given a page with a player.
+
+When scanned on a QR code reader inside a podcast app, like [CurioCaster](https://curiocaster.com/), the app can parse the `podcast:guid` value from the URL, allowing the podcast to be opened within the application.


### PR DESCRIPTION
Explanation about how fast-follow share links work, as a subsection of `podcast:guid`.