### PR TITLE
Change suggested by Alecks

### DIFF
--- a/proposal-docs/podping/podping.md
+++ b/proposal-docs/podping/podping.md
@@ -12,7 +12,7 @@ However, as pointed out in issue https://github.com/Podcastindex-org/podcast-nam
 
 This tag proposal will allow feed owners and the hosts of multiple feeds, to signal that future updates will be sent via Podping and there is no need to speculatively poll this rss feed.
 
-An additional benefit will derive if feeds signal the name or names of the Hive accounts authorized to send Podpings. These authorized Hive accounts will be included in a `<podcast:podpingAuth>` tag
+An additional benefit will derive if feeds signal the name or names of the Hive accounts authorized to send Podpings. These authorized Hive accounts will be included in a `<podcast:hiveAccount>` tag
 
 ## API Requirements
 
@@ -22,15 +22,15 @@ This tag can also contribute to a future API endpoint for the PodcastIndex which
 
 For the `<podcast:podping>` tag there is only one optional attribute `usesPodping` which will usually be set to `True` though could be set to `False` to specifically opt out of using Poding and indicate a feed must be polled by legacy RSS polling methods.
 
-For the optional but helpful `<podcast:podpingAuth>` tag there is one attribute, a single value with a single allowed Hive account.
+For the optional but helpful `<podcast:hiveAccount>` tag there is one attribute, a single value with a single Hive account which is allowed to issue `podpings` for this feed.
 
 ## Example
 
 ```xml
 <podcast:podping>
-    <podcast:podpingAuth account="podping.aaa"/>
-    <podcast:podpingAuth account="podping.bbb"/>
-    <podcast:podpingAuth account="podping.ccc"/>
+    <podcast:hiveAccount account="podping.aaa"/>
+    <podcast:hiveAccount account="podping.bbb"/>
+    <podcast:hiveAccount account="podping.ccc"/>
 </podcast:podping>
 ```
 


### PR DESCRIPTION
change podpingAuth to hiveAccount

@brianoflondon Please don't call it podPing auth :)  call it hiveAccount.

1) this doesn't meet the criteria of "authorization"
2) calling it what it is, as opposed to what it does, makes it apparent
3) hiveAccount makes it easier to transition to another implementation in the future if needed
