### PR TITLE
Revise soundbite proposal spec to leave title field blank if the podcaster does not provide a value for title

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -149,7 +149,7 @@ audio/video source of the soundbite is the audio/video given in the item's `<enc
 &nbsp; Multiple
 
 ### Node value
-&nbsp; This is a free form string from the podcast creator to specify a title for the soundbite.  If there is no node value, the title of the episode should be used.  Please do not exceed `128 characters`
+&nbsp; This is a free form string from the podcast creator to specify a title for the soundbite.  If the podcaster does not provide a value for the soundbite title, then leave the value blank, and podcast apps can decide to use the episode title or some other placeholder value in its place.  Please do not exceed `128 characters`
 for the node value or it may be truncated by aggregators.
 
 ### Attributes


### PR DESCRIPTION
I think the current phrasing of the soundbite tag in the spec sounds unclear, as it sounds like the RSS host should insert the episode title as the soundbite title if no soundbite title is provided. When the podcaster does not provide a soundbite title, it would be better if RSS hosts leave the soundbite title field blank so podcast apps can more reliably differentiate between soundbites that have podcaster-defined titles, and soundbites that do not and should instead use a placeholder value. Podcast apps can then decide on their own placeholder value (possibly the episode title) to use for soundbites without podcaster-defined titles.

There are different UX implications for soundbites that have podcaster-defined titles and soundbites that do not, so I think it would be an improvement to clear up the language in this part of the spec.