### PR TITLE
Integrate Nano cryptocurrency in V4V spec, adding documentation

### DIFF
--- a/value/value.md
+++ b/value/value.md
@@ -423,3 +423,37 @@ and guest.
   ...
 </channel>
 ```
+
+#### [Nano](https://nano.org)
+
+For the `<podcast:value>` tag, the following attributes MUST be used:
+ - `type` (*required*): "nano"
+ - `method` (*required*): "sendblock"
+ - `suggested` (*optional*): A float representing the amount in nano (eg. 0.025)
+
+For the `<podcast:valueRecipient>` tag, the following attributes MUST be used:
+ - `type`: "account"
+ - `address`: \<*destination nano_xxx address*\>
+ - `split`: \<*the number of shares*\>
+
+#### Example
+<details><summary>Click to expand example</summary>
+    ***Note:** The following is a made up example, and the example accounts shown are for demonstration purposes only.*
+    
+    ```xml
+    <podcast:value type="nano" method="sendblock" suggested="0.0000001">
+	<podcast:valueRecipient
+		name="John Vallis (Host)"
+		type="account"
+		address="nano_3fegpdys1a3ncscmhagn3yxdrf5s9kb8drorsi75399omnwjbcp87cyibzyx"
+		split="50"
+	/>
+	<podcast:valueRecipient
+		name="Paul Itoi (Guest)"
+		type="account"
+		address="nano_1ero6egquwf3bkh4h5ksf7ghumehn3c131opqe65bsi5q17huwjsnhcp8kxd"
+		split="50"
+	/>
+    </podcast:value>
+    ```
+</details>

--- a/value/value.md
+++ b/value/value.md
@@ -424,12 +424,14 @@ and guest.
 </channel>
 ```
 
-#### [Nano](https://nano.org)
+#### Nano
 
-For the `<podcast:value>` tag, the following attributes MUST be used:
+Specification for Value 4 Value integration with the [Nano](https://nano.org) cryptocurrency.
+
+For the `<podcast:value>` tag, the following attributes are applicable:
  - `type` (*required*): "nano"
  - `method` (*required*): "sendblock"
- - `suggested` (*optional*): A float representing the amount in nano (eg. 0.025)
+ - `suggested` (*optional*): A float representing the amount in nano (eg. 0.00025)
 
 For the `<podcast:valueRecipient>` tag, the following attributes MUST be used:
  - `type`: "account"
@@ -437,23 +439,23 @@ For the `<podcast:valueRecipient>` tag, the following attributes MUST be used:
  - `split`: \<*the number of shares*\>
 
 #### Example
-<details><summary>Click to expand example</summary>
-    ***Note:** The following is a made up example, and the example accounts shown are for demonstration purposes only.*
-    
-    ```xml
-    <podcast:value type="nano" method="sendblock" suggested="0.0000001">
-	<podcast:valueRecipient
-		name="John Vallis (Host)"
-		type="account"
-		address="nano_3fegpdys1a3ncscmhagn3yxdrf5s9kb8drorsi75399omnwjbcp87cyibzyx"
-		split="50"
-	/>
-	<podcast:valueRecipient
-		name="Paul Itoi (Guest)"
-		type="account"
-		address="nano_1ero6egquwf3bkh4h5ksf7ghumehn3c131opqe65bsi5q17huwjsnhcp8kxd"
-		split="50"
-	/>
+***Note:** The following is a made up example, and the accounts shown are for demonstration purposes only.*
+
+```xml
+<channel>
+    <podcast:value type="nano" method="sendblock" suggested="0.0001">
+        <podcast:valueRecipient
+            name="John Doe (Host)"
+            type="account"
+            address="nano_3fegpdys1a3ncscmhagn3yxdrf5s9kb8drorsi75399omnwjbcp87cyibzyx"
+            split="50"
+        />
+        <podcast:valueRecipient
+            name="Jane Doe (Guest)"
+            type="account"
+            address="nano_1ero6egquwf3bkh4h5ksf7ghumehn3c131opqe65bsi5q17huwjsnhcp8kxd"
+            split="50"
+        />
     </podcast:value>
-    ```
-</details>
+</channel>
+```


### PR DESCRIPTION
This adds a Value 4 Value specification and associated constants for the [Nano](https://nano.org) cryptocurrency.

If there's another procedure for registering and declaring a cryptocurrency in the V4V spec, please let me know and I'll be sure to do it.