### PR TITLE
Clarify podcast:images srcset url requirements

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -728,7 +728,7 @@ Example use for "music":
 `<podcast:images>`<br><br>
 This tag, when present, allows for specifying many different image sizes in a compact way at either the episode or channel level.  The syntax is borrowed from
 the HTML5 [srcset](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes) syntax.  It allows for describing multiple image sources with width and
-pixel hints directly in the attribute.
+pixel hints directly in the attribute.  Although the HTML5 `srcset` attribute allows relative urls, absolute urls are required in this tag - since the feed url may not represent an appropriate base url for relativization.
 
 ### Parent
 &nbsp; `<channel>` or `<item>`


### PR DESCRIPTION
Specify that absolute urls for the `srcset` attribute are required for `<podcast:images>`, even though the HTML5 `srcset` attribute allows relative urls.