### PR TITLE
use proper mime type for srt files #221

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -31,11 +31,12 @@ Detailed file format information and example files are [here](../transcripts/tra
 ### Attributes
  - **url (required):** URL of the podcast transcript.
 
- - **type (required):** Mime type of the file such as `text/plain`, `text/html`, `application/srt`, `text/vtt`, `application/json`
+ - **type (required):** Mime type of the file such as `text/plain`, `text/html`, `text/vtt`, `application/json`, `application/x-subrip`
 
  - **language (optional):** The language of the linked transcript. If there is no language attribute given, the linked file is assumed to be the same language that is specified by the RSS `<language>` element.
 
  - **rel (optional):** If the rel="captions" attribute is present, the linked file is considered to be a closed captions file, regardless of what the mime type is.  In that scenario, time codes are assumed to be present in the file in some capacity.
+
 
 ### Examples
 ```xml
@@ -43,7 +44,7 @@ Detailed file format information and example files are [here](../transcripts/tra
 ```
 
 ```xml
-<podcast:transcript url="https://example.com/episode1/transcript.srt" type="text/srt" rel="captions" />
+<podcast:transcript url="https://example.com/episode1/transcript.vtt" type="text/vtt" />
 ```
 
 ```xml
@@ -51,8 +52,9 @@ Detailed file format information and example files are [here](../transcripts/tra
 ```
 
 ```xml
-<podcast:transcript url="https://example.com/episode1/transcript.vtt" type="text/vtt" />
+<podcast:transcript url="https://example.com/episode1/transcript.srt" type="application/x-subrip" rel="captions" />
 ```
+
 
 
 


### PR DESCRIPTION
consistently use `application/x-subrip` for srt, unify order

