### PR TITLE
Update 1.0.md - Alternate enclosure bitrate

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -425,7 +425,7 @@ to allow for file integrity checking.
 ### Attributes
  - **type:** (required) Mime type of the media asset.
  - **length:** (required) Length of the file in bytes.
- - **bitrate:** (optional) Encoding bitrate of media asset.
+ - **bitrate:** (optional) Average encoding bitrate of the media asset, expressed in bits per second.
  - **height:** (optional) Height of the media asset for video formats.
  - **lang:** (optional) An [IETF language tag (BCP 47)](https://en.wikipedia.org/wiki/BCP_47) code identifying the language of this media.
  - **title:** (optional) A human-readable string identifying the name of the media asset. Should be limited to 32 characters for UX.


### PR DESCRIPTION
Added information on the bitrate attribute.
I explicitly added that the unit is bits per second. One could probably infer that from the examples, but this way is more explicit.