### PR TITLE
add RSS Blue support for GUID and Medium

### DIFF
--- a/docs/element-support.md
+++ b/docs/element-support.md
@@ -96,6 +96,7 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 1. [Buzzsprout](https://www.buzzsprout.com)
 2. [Castos](https://castos.com/introducing-podcast-2-0-support/)
 3. [Sounder.fm](https://feeds.sounder.fm/17048/rss.xml)
+4. [RSS Blue](https://rssblue.com/help/podcasting-2.0#progress-2)
 
 ## Value `<podcast:value>`
 1. [Castos](https://castos.com/earn-bitcoin-from-your-listeners/)

--- a/docs/element-support.md
+++ b/docs/element-support.md
@@ -102,3 +102,6 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 1. [Castos](https://castos.com/earn-bitcoin-from-your-listeners/)
 2. [usocial](http://usocial.me/history#v0.1.1)
 3. [RSS Blue](https://rssblue.com/help/podcast-metadata#lightning-node)
+
+## Medium `<podcast:medium>`
+1. [RSS Blue](https://rssblue.com/help/podcast-metadata#medium)


### PR DESCRIPTION
Hi!

Here is a test feed with both of the tags present: <https://rssblue.com/@test-podcast-3/feed>.

For `<podcast:guid>`, the correctness can be verified with [this tool](https://www.uuidtools.com/v5) by entering namespace `ead4c236-bf58-58c6-a2c6-a6b28d128cb6` and name `rssblue.com/@test-podcast-3/feed`.

For `<podcast:medium>`, I added support for `podcast`, `music`, `audiobook`, `newsletter`, and `blog`; adding `video` or `film` wouldn't make sense at the moment because we don't allow video uploads yet.

As a side note, RSS Blue now has [a page](https://rssblue.com/help/podcasting-2.0#progress-2) that explains Podcasting 2.0 in more detail and specifies the extent to which we have implemented certain features.