### PR TITLE
Add Alby to "value" category

### DIFF
--- a/docs/element-support.md
+++ b/docs/element-support.md
@@ -101,3 +101,4 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 1. [Castos](https://castos.com/earn-bitcoin-from-your-listeners/)
 2. [usocial](http://usocial.me/history#v0.1.1)
 3. [RSS Blue](https://rssblue.com/help/podcast-metadata#lightning-node)
+4. [Alby](https://getalby.com/podcast-wallet)


### PR DESCRIPTION
Alby provides podcaster wallets to receive bitcoin now. 
Functionalities include:

- receive boosts
- receive and display boostagrams
- display other payment meta data. 
- provide necessary credentials to create a value tag for the RSS feed
- display example value tag

[Alby podcaster wallets](https://getalby.com/podcast-wallet)
[Introduction to Alby's podcaster wallet for users](https://blog.getalby.com/bitcoin-payments-for-podcasters-with-alby/)