### PR TITLE
Update 1.0.md

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -176,13 +176,13 @@ for the node value or it may be truncated by aggregators.
 This element specifies a person of interest to the podcast.  It is primarily intended to identify people like hosts, co-hosts and guests.  Although, it is flexible enough to allow fuller credits to be given using the roles and groups that are listed in the [Podcast Taxonomy Project](https://podcasttaxonomy.com/)
 
 ### Parent
-&nbsp; `<channel>` or `<item>`
+&nbsp; `<channel>` (for a podcast) or `<item>` (for an individual episode)
 
-It is suggested that `<channel>` is always populated, and `<item>` is populated where needed. Where present, people information in `<item>` wholly replaces all information from the `<channel>`.
+It is suggested that `<channel>` is always populated, and `<item>` is populated where needed for an individual episode. Where present, people information in `<item>` wholly replaces all information from the `<channel>`.
 
 Publishers are expected to use the `podcast:person` element in the `<channel>` parent to set the _regular_ people involved in the podcast: the detail that would be expected to be seen in an overview of the show.
 
-Publishers are expected to use the `podcast:person` in the `<item>` parent to **replace** all existing information for an individual show.
+Publishers are expected to use the `podcast:person` in the `<item>` parent to **replace** all existing information for an individual episode.
 
 #### For example: _Terry and June_
 

--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -173,11 +173,28 @@ for the node value or it may be truncated by aggregators.
 <br><br><br><br><!-- Tag block -->
 ## Person
 `<podcast:person>`<br><br>
-This element specifies a person of interest to the podcast.  It is primarily intended to identify people like hosts, co-hosts and guests.  Although, it is flexible enough to allow fuller credits to be
-given using the roles and groups that are listed in the [Podcast Taxonomy Project](https://podcasttaxonomy.com/)
+This element specifies a person of interest to the podcast.  It is primarily intended to identify people like hosts, co-hosts and guests.  Although, it is flexible enough to allow fuller credits to be given using the roles and groups that are listed in the [Podcast Taxonomy Project](https://podcasttaxonomy.com/)
 
 ### Parent
-&nbsp; `<item>` or `<channel>`
+&nbsp; `<channel>` or `<item>`
+
+It is suggested that `<channel>` is always populated, and `<item>` is populated where needed. Where present, people information in `<item>` wholly replaces all information from the `<channel>`.
+
+Publishers are expected to use the `podcast:person` element in the `<channel>` parent to set the _regular_ people involved in the podcast: the detail that would be expected to be seen in an overview of the show.
+
+Publishers are expected to use the `podcast:person` in the `<item>` parent to **replace** all existing information for an individual show.
+
+#### For example: _Terry and June_
+
+The fictional podcast _Terry and June_ is normally hosted by Terry Scott and June Whitfield. Within `<channel>`, Terry Scott and June Whitfield are listed as the hosts. A podcast directory, or podcast app, should show Terry Scott and June Whitfield as the hosts of this show.
+
+For one episode, _Terry and June_ was hosted by Reginald Marsh and June Whitfield (Terry was away). In this case, the `<item>` for this episode should contain Reginald Marsh and June Whitfield as the hosts of this episode. A podcast app, when playing this episode, should show only Reginald Marsh and June Whitfield as the hosts of this episode. Because people information in `<item>` replaces all existing people information in `<channel>`, Terry Scott should not be visible as a host of this episode.
+
+#### For example: _Big Daddy_
+
+The fictional podcast _Big Daddy Interviews_ is hosted by Big Daddy, a wrestler. Within `<channel>`, Big Daddy is listed as the host. A podcast directory, or podcast app, should show Big Daddy as the host of this show.
+
+For one episode, _Big Daddy Interviews_ had a guest of Sid James. In this case, the `<item>` for this episode should contain Sid James as a guest, **and** Big Daddy as the host of this episode. Because people information in `<item>` replaces all existing people information in `<channel>`, Big Daddy should be re-stated as the host of this episode.
 
 ### Count
 &nbsp; Multiple


### PR DESCRIPTION
Clarification about where to use channel and item for the podcast:person tag, by using minor celebrities from 1970s British television.