### PR TITLE
Do not use HTTP protocol for URLs in podcast namespace tags

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -240,19 +240,19 @@ The full taxonomy list is [here](https://github.com/Podcastindex-org/podcast-nam
 
 ### Examples
 ```xml
-<podcast:person href="https://example.com/johnsmith/blog" img="http://example.com/images/johnsmith.jpg">John Smith</podcast:person>
+<podcast:person href="https://example.com/johnsmith/blog" img="https://example.com/images/johnsmith.jpg">John Smith</podcast:person>
 ```
 
 ```xml
-<podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="http://example.com/images/janedoe.jpg">Jane Doe</podcast:person>
+<podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="https://example.com/images/janedoe.jpg">Jane Doe</podcast:person>
 ```
 
 ```xml
-<podcast:person role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
+<podcast:person role="guest" href="https://www.wikipedia/alicebrown" img="https://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
 ```
 
 ```xml
-<podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="http://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
+<podcast:person group="writing" role="guest" href="https://www.wikipedia/alicebrown" img="https://example.com/images/alicebrown.jpg">Alice Brown</podcast:person>
 ```
 
 ```xml
@@ -506,14 +506,14 @@ to allow for file integrity checking.
     <podcast:source uri="https://example.com/file-0.mp3" />
     <podcast:source uri="ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y" />
     <podcast:source uri="https://example.com/file-0.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://example.onion/file-0.mp3" />
+    <podcast:source uri="https://example.onion/file-0.mp3" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="10562995" bitrate="681483.55" height="1080">
     <podcast:source uri="https://example.com/file-1080.mp4" />
     <podcast:source uri="ipfs://QmfQKJcp2xdByEt8mzWr1AJUhwvb9rdWPoacvdq2roDhgh" />
     <podcast:source uri="https://example.com/file-1080.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://example.onion/file-1080.mp4" />
+    <podcast:source uri="https://example.onion/file-1080.mp4" />
 </podcast:alternateEnclosure>
 ```
 
@@ -541,7 +541,7 @@ present within every `<podcast:alternateEnclosure>` element.
     <podcast:source uri="https://example.com/file-720.mp4" />
     <podcast:source uri="ipfs://QmX33FYehk6ckGQ6g1D9D3FqZPix5JpKstKQKbaS8quUFb" />
     <podcast:source uri="https://example.com/file-720.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://example.onion/file-720.mp4" />
+    <podcast:source uri="https://example.onion/file-720.mp4" />
 </podcast:alternateEnclosure>
 ```
 

--- a/docs/schema/podcast-example.xml
+++ b/docs/schema/podcast-example.xml
@@ -8,12 +8,12 @@
 	<podcast:location geo="12345">12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678</podcast:location>
 	<podcast:locked owner="podcastowner@example.com">yes</podcast:locked>
 	<podcast:person group="visuals" role="cover art designer" href="https://example.com/artist/beckysmith">Becky Smith</podcast:person>
-	<podcast:person href="https://curry.com" img="http://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
-	<podcast:person href="https://en.wikipedia.org/wiki/Adam_Curry" img="http://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+	<podcast:person href="https://curry.com" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+	<podcast:person href="https://en.wikipedia.org/wiki/Adam_Curry" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
 	<podcast:person href="https://www.podchaser.com/creators/adam-curry-107ZzmWE5f" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
-	<podcast:person role="guest" href="https://example.com/blog/daveajones/" img="http://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+	<podcast:person role="guest" href="https://example.com/blog/daveajones/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
 	<podcast:person role="guest" href="https://github.com/daveajones/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
-	<podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="http://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+	<podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
 	<podcast:season name="Podcasting 2.0">1</podcast:season>
 	<podcast:soundbite startTime="29.32" duration="34.0" />
 	<podcast:soundbite startTime="33.833" duration="60.0" />

--- a/example.xml
+++ b/example.xml
@@ -143,8 +143,8 @@
             <podcast:chapters url="https://example.com/ep2_chapters.json" type="application/json"/>
             <podcast:soundbite startTime="45.4" duration="56.0" />
             <podcast:transcript url="https://example.com/ep2/transcript.txt" type="text/plain" />
-            <podcast:person href="https://en.wikipedia.org/wiki/Adam_Curry" img="http://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
-            <podcast:person role="guest" href="https://example.com/blog/daveajones/" img="http://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+            <podcast:person href="https://en.wikipedia.org/wiki/Adam_Curry" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+            <podcast:person role="guest" href="https://example.com/blog/daveajones/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
             <podcast:person group="visuals" role="cover art designer" href="https://example.com/artist/marcusbrown">Marcus Brown</podcast:person>
 
             <enclosure url="https://example.com/file-02.mp3" length="43113000" type="audio/mpeg" />
@@ -194,8 +194,8 @@
             <podcast:chapters url="https://example.com/ep1_chapters.json" type="application/json"/>
             <podcast:soundbite startTime="29.32" duration="34.0" />
             <podcast:transcript url="https://example.com/ep1/transcript.txt" type="text/plain" />
-            <podcast:person href="https://curry.com" img="http://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
-            <podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="http://example.com/images/davejones.jpg">Dave Jones</podcast:person>
+            <podcast:person href="https://curry.com" img="https://example.com/images/adamcurry.jpg">Adam Curry</podcast:person>
+            <podcast:person role="guest" href="https://www.imdb.com/name/nm0427852888/" img="https://example.com/images/davejones.jpg">Dave Jones</podcast:person>
             <podcast:person group="visuals" role="cover art designer" href="https://example.com/artist/jebickmorton">Jebick Morton</podcast:person>
             
             <enclosure url="https://example.com/file-01.mp3" length="43111403" type="audio/mpeg" />

--- a/proposal-docs/alternateEnclosure/alternateEnclosure.md
+++ b/proposal-docs/alternateEnclosure/alternateEnclosure.md
@@ -118,53 +118,53 @@ Example of content served via audio (mp3) and video in different resolutions (mp
     <podcast:source uri="https://best-podcast.com/file-0.mp3" />
     <podcast:source uri="ipfs://QmdwGqd3d2gFPGeJNLLCshdiPert45fMu84552Y4XHTy4y" />
     <podcast:source uri="https://best-podcast.com/file-0.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somerandom.onion/file-0.mp3" />
+    <podcast:source uri="https://somerandom.onion/file-0.mp3" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="10562995" bitrate="681483.55" height="1080">
     <podcast:source uri="https://best-podcast.com/file-1080.mp4" />
     <podcast:source uri="ipfs://QmfQKJcp2xdByEt8mzWr1AJUhwvb9rdWPoacvdq2roDhgh" />
     <podcast:source uri="https://best-podcast.com/file-1080.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somrandom.onion/file-1080.mp4" />
+    <podcast:source uri="https://somrandom.onion/file-1080.mp4" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="7924786" bitrate="511276.52" height="720">
     <podcast:source uri="https://best-podcast.com/file-720.mp4" />
     <podcast:source uri="ipfs://QmX33FYehk6ckGQ6g1D9D3FqZPix5JpKstKQKbaS8quUFb" />
     <podcast:source uri="https://best-podcast.com/file-720.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somrandom.onion/file-720.mp4" />
+    <podcast:source uri="https://somrandom.onion/file-720.mp4" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="6081197" bitrate="392335.29" height="480">
     <podcast:source uri="https://best-podcast.com/file-480.mp4" />
     <podcast:source uri="ipfs://QmQHNcr88kHp2ieNQYcBRczM7XpMtjRSQcLek6CaJwd81m" />
     <podcast:source uri="https://best-podcast.com/file-480.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somrandom.onion/file-480.mp4" />
+    <podcast:source uri="https://somrandom.onion/file-480.mp4" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="4086007" bitrate="327833.03" height="360">
     <podcast:source uri="https://best-podcast.com/file-360.mp4" />
     <podcast:source uri="ipfs://QmeK3EQMuV6cR766kuyG2QUUEJqUVfkJKGPNRceXzXC3ED" />
     <podcast:source uri="https://best-podcast.com/file-360.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somrandom.onion/file-360.mp4" />
+    <podcast:source uri="https://somrandom.onion/file-360.mp4" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="video/mp4" length="2490970" bitrate="263613.35" height="240">
     <podcast:source uri="https://best-podcast.com/file-240.mp4" />
     <podcast:source uri="ipfs://QmdjB94TUMSQu1P8QvPnGnPjNLiWycjtraSaCsiVi4xUNi" />
     <podcast:source uri="https://best-podcast.com/file-240.torrent" contentType="application/x-bittorrent" />
-    <podcast:source uri="http://somrandom.onion/file-240.mp4" />
+    <podcast:source uri="https://somrandom.onion/file-240.mp4" />
 </podcast:alternateEnclosure>
 <podcast:alternateEnclosure type="application/x-mpegURL" length="10562995">
     <podcast:source uri="https://best-podcast.com/master.m3u8" />
     <podcast:source uri="ipfs://exampleLinkThatDoesntWorkHLS" />
-    <podcast:source uri="http://somerandom.onion/master.m3u8" />
+    <podcast:source uri="https://somerandom.onion/master.m3u8" />
 </podcast:alternateEnclosure>
 
 <podcast:alternateEnclosure type="application/dash+xml" length="10562995">
     <podcast:source uri="https://example.com/master.mpd" />
     <podcast:source uri="ipfs://exampleLinkThatDoesntWorkDASH" />
-    <podcast:source uri="http://somerandom.onion/master.mpd" />
+    <podcast:source uri="https://somerandom.onion/master.mpd" />
 </podcast:alternateEnclosure>
 ```
 

--- a/proposal-docs/license/license.md
+++ b/proposal-docs/license/license.md
@@ -42,9 +42,9 @@ This matter is very complex so this specification only intends to scratch its su
    - `url` (required): This is the url to the license file.
 
    Examples:
-   - `<podcast:license url="http://creativecommons.org/licenses/by-nd/4.0/">(CC BY-ND 4.0)</podcast:license>`
-   - `<podcast:license url="http://creativecommons.org/licenses/by-nc-nd/4.0/">(CC BY-NC-ND 4.0)</podcast:license>`
-   - `<podcast:license url="http://domain.tld/license.txt">© My Company 2021 - All Rights Reserved</podcast:license>`
+   - `<podcast:license url="https://creativecommons.org/licenses/by-nd/4.0/">(CC BY-ND 4.0)</podcast:license>`
+   - `<podcast:license url="https://creativecommons.org/licenses/by-nc-nd/4.0/">(CC BY-NC-ND 4.0)</podcast:license>`
+   - `<podcast:license url="https://domain.tld/license.txt">© My Company 2021 - All Rights Reserved</podcast:license>`
  
    
    Discussion here:


### PR DESCRIPTION
This is to comply with the following in the [podcast namespace specification](https://podcastindex.org/namespace/1.0#podcast-tags):

> Anywhere the url of a hyper-text based resource is specified, it must be given as `https:` and not `http:`.