### PR TITLE
socialInteract: URI vs URL text

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -964,7 +964,7 @@ Example (disabled):
 <podcast:socialInteract protocol="disabled" />
 ```
 
-
+* For **activitypub**, Mastodon or Pleroma's posting API returns a URI (a fully-formed URL with a GUID in it), and a URL (the HTML page where the comment lives). While both of these are acceptable values for the `uri` field referenced in the `socialInteract` specification, we'd recommend using the URI value.
 
 <br><br><br><br><!-- Tag block -->
 ## Block


### PR DESCRIPTION
Clarifying which to use in the URI field if you're given both a URI and URL, as boringly hammered out in podcast.social over the weekend.