### PR TITLE
podcast:value may be multiple elements

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -647,7 +647,7 @@ this tag works and what it is capable of.
 &nbsp; `<channel>` or `<item>`
 
 ### Count
-&nbsp; Single
+&nbsp; Multiple
 
 ### Node Value
 &nbsp; The node value must be one or more `<podcast:valueRecipient>` elements.


### PR DESCRIPTION
As agreed by @daveajones elsewhere, this tag may be present multiple times, to allow for different payment mechanisms.