### PR TITLE
Update element-support.md to indicate RedCircle's support for various tags

### DIFF
--- a/docs/element-support.md
+++ b/docs/element-support.md
@@ -20,6 +20,7 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 13. [Audioboom](https://twitter.com/Audioboom/status/1478378244638494733)
 14. [Caproni](https://caproni.fm/en)
 15. [RSS Blue](https://rssblue.com/help/episode-metadata#transcript)
+16. [RedCircle](https://redcircle.com)
 
 ## Locked `<podcast:locked>`
 1. [Buzzsprout](https://www.buzzsprout.com/blog/podcast-locking)
@@ -34,6 +35,7 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 10. [Caproni](https://caproni.fm/en)
 11. [Castos](https://castos.com/introducing-podcast-2-0-support/)
 12. [RSS Blue](https://rssblue.com/help/podcast-metadata#locked)
+13. [RedCircle](https://redcircle.com)
 
 ## Funding `<podcast:funding>`
 1. [Buzzsprout](https://www.buzzsprout.com/)
@@ -54,6 +56,7 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 16. [Caproni](https://caproni.fm/en)
 17. [Castos](https://castos.com/introducing-podcast-2-0-support/)
 18. [RSS Blue](https://rssblue.com/help/podcast-metadata#funding-url)
+19. [RedCircle](https://redcircle.com)
 
 ## Chapters `<podcast:chapters>`
 1. [Podcast Chapters](https://chaptersapp.com/faq/jsonExport.html)
@@ -94,6 +97,7 @@ For elements that are included in the official [DTD](https://github.com/Podcasti
 1. [Buzzsprout](https://www.buzzsprout.com)
 2. [Castos](https://castos.com/introducing-podcast-2-0-support/)
 3. [RSS Blue](https://rssblue.com/help/podcasting-2.0#progress-2)
+4. [RedCircle](https://redcircle.com)
 
 ## Value `<podcast:value>`
 1. [Castos](https://castos.com/earn-bitcoin-from-your-listeners/)


### PR DESCRIPTION
Some screenshots from our UI / our feeds:


<img width="462" alt="image" src="https://user-images.githubusercontent.com/1679344/224227711-79e0c79a-2f8b-430b-811e-747e5568ee88.png">

<img width="748" alt="image" src="https://user-images.githubusercontent.com/1679344/224227805-04156c3e-34fc-48eb-a950-30f429c8e760.png">

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/1679344/224227905-969f8edb-7000-4eba-8f12-944dbab024ec.png">

