### PR TITLE
bLIP10: Change reply_custom_key to int

### DIFF
--- a/value/blip-0010.md
+++ b/value/blip-0010.md
@@ -154,7 +154,7 @@ Other optional fields:
   must be capable of receiving keysend payments. If this field contains an "@" symbol, it should
   be interpreted as a
   "[lightning address](https://github.com/andrerfneves/lightning-address/blob/master/README.md#tldr)".
-* `reply_custom_key` (str) The custom key for routing a reply payment to the sender. This field should not be present
+* `reply_custom_key` (int) The custom key for routing a reply payment to the sender. This field should not be present
   if it is not required for payment routing.
 * `reply_custom_value` (str) The custom value for routing a reply payment to the sender. This field should not be
   present if it is not required for payment routing.


### PR DESCRIPTION
I think making reply_custom_key an int instead of an str would make more sense. TLV keys are ints anyway so using ints will lead to less confusion and errors.