### PR TITLE
Fixing broken markdown links

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -173,10 +173,8 @@ link.  Please do not exceed `128 characters` for the node value or it may be tru
 <br><br><br><br><!-- Tag block -->
 ## Chapters
 `<podcast:chapters>`<br><br>
-Links to an external file (see example file) containing chapter data for the episode. See the [jsonChapters.md]
-(https://github.com/Podcastindex-org/podcast-namespace/blob/main/chapters/jsonChapters.md) file for a description of 
-the chapter file syntax. And, see the [example.json](https://github.
-com/Podcastindex-org/podcast-namespace/blob/main/chapters/example.json) example file for a real world example.
+Links to an external file (see example file) containing chapter data for the episode. See the [jsonChapters.md](../chapters/jsonChapters.md) file for a description of 
+the chapter file syntax. And, see the [example.json](../chapters/example.json) example file for a real world example.
 
 Benefits with this approach are that chapters do not require altering audio files, and the chapters can be edited 
 after publishing, since they are a separate file that can be requested on playback (or cached with download). JSON 
@@ -207,8 +205,7 @@ requiring no additional work for the publisher.
 `<podcast:soundbite>`<br><br>
 Points to one or more soundbites within a podcast episode. The intended use includes episodes previews, 
 discoverability, audiogram generation, episode highlights, etc. It should be assumed that the audio/video source of 
-the soundbite is the audio/video given in the item's [`<enclosure>`](https://cyber.harvard.edu/rss/rss.
-html#ltenclosuregtSubelementOfLtitemgt) element.
+the soundbite is the audio/video given in the item's [`<enclosure>`](https://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) element.
 
 ### Parent
 &nbsp; `<item>`
@@ -292,13 +289,12 @@ characters` for the node value or it may be truncated by aggregators.
    If `group` is not present, then "cast" is assumed.
  - **img:** (optional) This is the url of a picture or avatar of the person.
  - **href:** (optional) The url to a relevant resource of information about the person, such as a homepage or 
-   third-party profile platform. Please see the [example feed](https://github.
-   com/Podcastindex-org/podcast-namespace/blob/main/example.xml) for possible choices of what to use here.
+   third-party profile platform. Please see the [example feed](../example.xml) for possible choices of what to use here.
 
 The `role` and `group` attributes are case-insensitive.  So, "Host" is the same as "host", and "Cover Art Designer" 
 is the same as "cover art designer".
 
-The full taxonomy list is [here](https://github.com/Podcastindex-org/podcast-namespace/blob/main/taxonomy.json) as a 
+The full taxonomy list is [here](../taxonomy.json) as a 
 json file.
 
 ### Examples
@@ -349,7 +345,7 @@ json file.
 `<podcast:location>`<br><br>
 This tag is intended to describe the location of editorial focus for a podcast's content (i.e. "what place is this 
 podcast about?").  The tag has many use cases and is one of the more complex ones.  You are **highly encouraged** to 
-read the full [implementation document](https://github.com/Podcastindex-org/podcast-namespace/blob/main/location/location.md) before starting to code for it.
+read the full [implementation document](../location/location.md) before starting to code for it.
 
 ### Parent
 &nbsp; `<item>` or `<channel>`
@@ -531,8 +527,7 @@ later be matched up with a `<podcast:season>4<podcast:season>` tag when it is pu
 `<podcast:license>`<br><br>
 This element defines a license that is applied to the audio/video content of a single episode, or the audio/video of 
 the podcast as a whole.  Custom licenses must always include a url attribute.  Implementors are encouraged to read 
-the license tag companion [document](https://github.
-com/Podcastindex-org/podcast-namespace/blob/main/proposal-docs/license/license.md) for a more complete picture of 
+the license tag companion [document](../proposal-docs/license/license.md) for a more complete picture of 
 what this tag is intended to accomplish.
 
 ### Parent
@@ -542,8 +537,7 @@ what this tag is intended to accomplish.
 &nbsp; Single
 
 ### Node Value
-&nbsp; The node value must be a lower-cased reference to a license "identifier" defined in the [SPDX License List]
-(https://spdx.org/licenses/) file if the license being used is a well-known, public license.  Or, if it is a custom 
+&nbsp; The node value must be a lower-cased reference to a license "identifier" defined in the [SPDX License List](https://spdx.org/licenses/) file if the license being used is a well-known, public license.  Or, if it is a custom 
 license, it must be a free form abbreviation of the name of the license as you reference it publicly. Please do not 
 exceed `128 characters` for the node value or it may be truncated by aggregators.
 
@@ -565,14 +559,12 @@ exceed `128 characters` for the node value or it may be truncated by aggregators
 <br><br><br><br><!-- Tag block -->
 ## Alternate Enclosure
 `<podcast:alternateEnclosure>`<br><br>
-This element is meant to provide different versions of, or companion media to the main [`<enclosure>`](https://cyber.
-harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) file.  This could be an audio only version of a video 
+This element is meant to provide different versions of, or companion media to the main [`<enclosure>`](https://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) file.  This could be an audio only version of a video 
 podcast to allow apps to switch back and forth between audio/video, lower (or higher) bitrate versions for bandwidth 
 constrained areas, alternative codecs for different device platforms, alternate URI schemes and download types such 
 as IPFS or WebTorrent, commentary tracks or supporting source clips, etc.
 
-This is a complex tag, so implementors are highly encouraged to read the companion [document](https://github.
-com/Podcastindex-org/podcast-namespace/blob/main/proposal-docs/alternateEnclosure/alternateEnclosure.md) for a 
+This is a complex tag, so implementors are highly encouraged to read the companion [document](../proposal-docs/alternateEnclosure/alternateEnclosure.md) for a 
 fuller understanding of how this tag works and what it is capable of.
 
 ### Parent
@@ -681,8 +673,7 @@ every `<podcast:alternateEnclosure>` element.
 <br><br><br><br><!-- Tag block -->
 ## Integrity
 `<podcast:integrity>`<br><br>
-This element defines a method of verifying integrity of the media given either an [SRI-compliant integrity string]
-(https://www.w3.org/TR/SRI/) (preferred) or a base64 encoded PGP signature.  This element is optional within a 
+This element defines a method of verifying integrity of the media given either an [SRI-compliant integrity string](https://www.w3.org/TR/SRI/) (preferred) or a base64 encoded PGP signature.  This element is optional within a 
 `<podcast:alternateEnclosure>` element.  It allows to ensure that the file has not been tampered with.
 
 ### Parent
@@ -711,10 +702,7 @@ This element defines a method of verifying integrity of the media given either a
 `<podcast:guid>`<br><br>
 This element is used to declare a unique, global identifier for a podcast. The value is a UUIDv5, and is easily 
 generated from the RSS feed url, with the **protocol scheme and trailing slashes stripped off**, combined with a 
-unique "podcast" namespace which has a UUID of `ead4c236-bf58-58c6-a2c6-a6b28d128cb6`. Tools like [this one]
-(https://www.uuidtools.com/v5) can help generate these values by hand. Or, language libraries like [this one]
-(https://github.com/sporkmonger/uuidtools) in Ruby are widely available. Specifically for podcasts, [this tool from 
-RSS Blue](https://tools.rssblue.com/podcast-guid) can help generate a GUID by hand.
+unique "podcast" namespace which has a UUID of `ead4c236-bf58-58c6-a2c6-a6b28d128cb6`. Tools like [this one](https://www.uuidtools.com/v5) can help generate these values by hand. Or, language libraries like [this one](https://github.com/sporkmonger/uuidtools) in Ruby are widely available. Specifically for podcasts, [this tool from RSS Blue](https://tools.rssblue.com/podcast-guid) can help generate a GUID by hand.
 
 A podcast gets assigned a podcast:guid once in its lifetime using its current feed url (at the time of assignment) 
 as the seed value. That GUID is then meant to follow the podcast from then on, for the duration of its life, even if 
@@ -788,8 +776,7 @@ the payments, and a suggested amount denominated in the given cryptocurrency.
 This element can exist at either the `<channel>` or `<item>` level.  When it exists at the `<item>` level, it should 
 be treated as an "override" of whatever is defined at the `<channel>` level.
 
-This is a complex tag, so implementors are HIGHLY encouraged to read the companion [document](https://github.
-com/Podcastindex-org/podcast-namespace/blob/main/value/value.md) for a complete understanding of how
+This is a complex tag, so implementors are HIGHLY encouraged to read the companion [document](../value/value.md) for a complete understanding of how
 this tag works and what it is capable of.
 
 ### Parent
@@ -828,8 +815,7 @@ This element may only exist within a parent `<podcast:value>` element.
 
 There is no limit on how many `valueRecipient` elements can be present in a given `<podcast:value>` element.
 
-This is a complex tag, so implementors are HIGHLY encouraged to read the companion [document](https://github.
-com/Podcastindex-org/podcast-namespace/blob/main/value/value.md) for a complete understanding of how this tag works 
+This is a complex tag, so implementors are HIGHLY encouraged to read the companion [document](../value/value.md) for a complete understanding of how this tag works 
 and what it is capable of.
 
 ### Parent
@@ -1000,8 +986,7 @@ Example use for a "music" playlist feed:
 ## Images
 `<podcast:images>`<br><br>
 This tag, when present, allows for specifying many different image sizes in a compact way at either the episode or 
-channel level.  The syntax is borrowed from the HTML5 [srcset](https://html.spec.whatwg.org/multipage/images.
-html#srcset-attributes) syntax.  It allows for describing multiple image sources with width and pixel hints directly 
+channel level.  The syntax is borrowed from the HTML5 [srcset](https://html.spec.whatwg.org/multipage/images.html#srcset-attributes) syntax.  It allows for describing multiple image sources with width and pixel hints directly 
 in the attribute.  Although the HTML5 `srcset` attribute allows relative urls, absolute urls are required in this 
 tag - since the feed url may not represent an appropriate base url for relativization.
 
@@ -1052,9 +1037,7 @@ All tags that are valid as children of a standard `<item>` tag are also valid as
 
 When specifying the audio/video source, the [`<podcast:alternateEnclosure>`](#alternate-enclosure) tag is highly 
 encouraged since it gives the broadest coverage of possible stream types and is explicit in it's communication of 
-what transport protocol and media codecs are being used. In addition to [`<podcast:alternateEnclosure>`]
-(#alternate-enclosure), a standard [`<enclosure>`](https://cyber.harvard.edu/rss/rss.
-html#ltenclosuregtSubelementOfLtitemgt) should also be given as a fallback to support podcast apps that don't yet 
+what transport protocol and media codecs are being used. In addition to [`<podcast:alternateEnclosure>`](#alternate-enclosure), a standard [`<enclosure>`](https://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) should also be given as a fallback to support podcast apps that don't yet 
 implement [`<podcast:alternateEnclosure>`](#alternate-enclosure). 
 
 Regardless of which enclosure tag is used, feed 
@@ -1072,8 +1055,7 @@ a page provided by their hosting company or a third party platform they have cho
 stream to multiple platforms at once can also use the [`<podcast:contentLink>`](#content-link) tag to provide links 
 to those other platforms.
 
-A robust, well-written `<podcast:liveItem>` tag will include all three of:  [`<podcast:alternateEnclosure>`]
-(#alternate-enclosure), [`<enclosure>`](https://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) 
+A robust, well-written `<podcast:liveItem>` tag will include all three of:  [`<podcast:alternateEnclosure>`](#alternate-enclosure), [`<enclosure>`](https://cyber.harvard.edu/rss/rss.html#ltenclosuregtSubelementOfLtitemgt) 
 and [`<podcast:contentLink>`](#content-link) to ensure the broadest interopability with podcast apps.
 
 The function of `<guid>` within a live item tag is the same as it is within a regular item.  If the `<guid>` of a 
@@ -1266,7 +1248,7 @@ In plain language, the sequence of discovery an ingesting platform should use is
 &nbsp; Multiple
 
 ### Attributes
- - **id** (optional) A single entry from the [service slug list](https://github.com/Podcastindex-org/podcast-namespace/blob/main/serviceslugs.txt).
+ - **id** (optional) A single entry from the [service slug list](../serviceslugs.txt).
 
 ### Node value
 &nbsp; The node value must be "yes" or "no".
@@ -1302,8 +1284,7 @@ In plain language, the sequence of discovery an ingesting platform should use is
 `<podcast:txt>`<br><br>
 This element holds free-form text and is modeled after the DNS "[TXT](https://en.wikipedia.org/wiki/TXT_record)" 
 record.  It's meant to allow for usages that might be niche or otherwise not rise to the level of needing a 
-dedicated tag.  Just like TXT records in DNS allowed for new things like [SPF](https://en.wikipedia.
-org/wiki/Sender_Policy_Framework#Implementation) to evolve, this tag can allow novel techniques to be created and 
+dedicated tag.  Just like TXT records in DNS allowed for new things like [SPF](https://en.wikipedia.org/wiki/Sender_Policy_Framework#Implementation) to evolve, this tag can allow novel techniques to be created and 
 sandboxed without a formalization process.
 
 ### Parent
@@ -1442,12 +1423,10 @@ do not exceed `128 characters` for the node value or it may be truncated by aggr
 ### Attributes
 * **complete (optional):** Boolean specifying if the podcast has no intention to release further episodes. If not 
   set, this should be assumed to be false.
-* **dtstart (optional):** The `date` or `datetime` the recurrence rule begins as an [ISO8601-fornmatted]
-  (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) string. If the 
+* **dtstart (optional):** The `date` or `datetime` the recurrence rule begins as an [ISO8601-fornmatted](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) string. If the 
   `rrule` contains a value for `COUNT`, then this attribute is required. If the `rrule` contains a value for `UNTIL`,
   then the value of this attribute must be formatted to the same date/datetime standard.
-* **rrule (recommended):** A recurrence rule as defined in [iCalendar RFC 5545 Section 3.3.10](https://www.
-  rfc-editor.org/rfc/rfc5545#section-3.3.10).
+* **rrule (recommended):** A recurrence rule as defined in [iCalendar RFC 5545 Section 3.3.10](https://www.rfc-editor.org/rfc/rfc5545#section-3.3.10).
 
 ### Examples
 Recreating most of Apple Podcasts Connect’s “Update Frequency” values is easily achieved:


### PR DESCRIPTION
The formatting introduced in 4967ffcc95a085767b431b72c5c8b6ecb5742b48 broke many markdown links. This commit removes only the line breaks that are breaking links as well converting some absolute links to relative.