### PR TITLE
fix typo in fast-follow link example

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -752,8 +752,7 @@ different platforms.
 
 &nbsp; `type` is currently `podcast`, but may be extended in future.
 
-&nbsp; A working example is https://podnews.net/podcast/i8xe9/listen#fastfollow-podcast:9b024349-ccf0-5f69-a609
--6b82873eab3c or the QR code given below.
+&nbsp; A working example is https://podnews.net/podcast/i8xe9/listen#fastfollow-podcast:9b024349-ccf0-5f69-a609-6b82873eab3c or the QR code given below.
 
 &nbsp; ![podnews-qr](https://user-images.githubusercontent.com/231941/127796108-d819de43-6c0e-4c7b-9579-ed1f19989443.png)
 


### PR DESCRIPTION
Not sure though if the example is really valid as this part of the link is what podnews is using https://podnews.net/podcast/i8xe9

Also tried as an alternative without luck https://curiocaster.com/#fastfollow-podcast:396d9ae0-da7e-5557-b894-b606231fa3ea