### PR TITLE
Remove hasArtwork leftovers

### DIFF
--- a/chapters/exampleComplex.json
+++ b/chapters/exampleComplex.json
@@ -11,8 +11,7 @@
     },
     {
       "startTime": 168,
-      "title": "Hearing Aids",
-      "hasArtwork": "chapter1.jpg"
+      "title": "Hearing Aids"
     },
     {
       "startTime": 260,

--- a/chapters/jsonChapters.md
+++ b/chapters/jsonChapters.md
@@ -158,8 +158,7 @@ chapter list, but allows for different artwork to be shown:
         },
         {
             "startTime": 168,
-            "title": "Hearing Aids",
-            "hasArtwork": "chapter1.jpg"
+            "title": "Hearing Aids"
         },
         {
             "startTime": 260,


### PR DESCRIPTION
After reading https://github.com/Podcastindex-org/podcast-namespace/issues/232 and https://github.com/Podcastindex-org/podcast-namespace/issues/91, I think that this commit https://github.com/Podcastindex-org/podcast-namespace/commit/b89df3cfed17d0dc7a0ab34f0ff9a869efca078e missed deleting some hasArtwork.