### PR TITLE
Updated TLV instructions for remote feed and item guids.

### DIFF
--- a/value/blip-0010.md
+++ b/value/blip-0010.md
@@ -158,11 +158,12 @@ Other optional fields:
   if it is not required for payment routing.
 * `reply_custom_value` (str) The custom value for routing a reply payment to the sender. This field should not be
   present if it is not required for payment routing.
-* `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block because a different feed referenced
-  it in a `<podcast:valueTimeSplit>` tag. When that happens, this field will contain the guid of the referencing feed.
-* `remote_item_guid` (str) Sometimes a payment will be sent to an episode's value block because a different feed
-  referenced it in a `<podcast:valueTimeSplit>` tag. When that happens, this field will contain the guid of the 
-  referencing feed's `<item>`.
+* `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block by way of a `<podcast:valueTimeSplit>`
+  tag containing a single `<podcast:remoteItem>` tag. When that happens, this field will contain the `feedGuid` attribute from
+  the `<podcast:remoteItem>` tag.
+* `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block by way of a `<podcast:valueTimeSplit>`
+  tag containing a single `<podcast:remoteItem>` tag having an `itemGuid` attribute. When that happens, this field will contain
+  the `itemGuid` attribute from the `<podcast:remoteItem>` tag.
 
 <br>
 


### PR DESCRIPTION
Updated the TLV docs for remote_(feed|item)_guid as per discussion on the helipad repo
https://github.com/Podcastindex-org/helipad/issues/80