### PR TITLE
Allow to identify a boost/stream; clarify `uuid`

### DIFF
--- a/value/blip-0010.md
+++ b/value/blip-0010.md
@@ -149,7 +149,8 @@ Other optional fields:
   serialized string should be hashed with `sha256` to obtain the value.
 * `speed` (str) Speed in which the podcast was playing, in decimal notation at the time the payment was sent. So 0.5
   is half speed and 2 is double speed.
-* `uuid` (str) Unique UUID of the payment.
+* `boost_uuid` (str) UUID for the boost/stream/auto payment. If there are several recipients, the same identifier should be sent to all of them.
+* `uuid` (str) UUID of a payment sent out to a single recipient.
 * `reply_address` (str) The pubkey of the lightning node that can receive payments for the sender. The node given
   must be capable of receiving keysend payments. If this field contains an "@" symbol, it should
   be interpreted as a


### PR DESCRIPTION
Currently, the description of `uuid` seems ambiguous—it is not clear whether the payment refers to the one made by the listener or the one sent out the individual recipient. Podverse and Podcast Guru interpret it as the latter.

Anyway, identifying the boost or stream by the listener is still useful. For example, suppose there are feed recipients Alice and BoostBot, and, during a value time split, another feed is referenced with recipients Bob and BoostBot. BoostBot is likely to receive two identical TLV records (except for `uuid`). It is then not clear whether to count this as a single boost or two boosts for analytics' purposes. Looking at the splits and the timing of the payments, it's possible to make good guesses, but none of them are foolproof.

Therefore, I'm proposing `boost_uuid`, which uniquely identifies the payment made by the *listener*.

Here's the pseudocode of how apps may handle it:

```
boost_uuid = new_uuid()

for recipient in recipients:
  recipient.tlv["boost_uuid"] = boost_uuid
  recipient.tlv["uuid"] = new_uuid()
  send_payment(recipient)
```