### PR TITLE
feat: Add a new section on the value of Blip-0010

### DIFF
--- a/value/blip-0010.md
+++ b/value/blip-0010.md
@@ -12,7 +12,7 @@ License: CC0
 
 Using Value 4 Value apps, listeners can send sats to the podcasts they listen to. A per-minute payment is
 called a `stream`, a manually triggered payment is called a `boost` and an automatically recurring (i.e. scheduled)
-payment is called an `auto` payment. The `auto` and `boost` action types may contain a text message in the `message` 
+payment is called an `auto` payment. The `auto` and `boost` action types may contain a text message in the `message`
 property.  The `stream` type should not.
 
 The payload is a simple JSON structure that is encoded as a TLV in the Lightning payment when it is sent. This
@@ -142,7 +142,7 @@ Other optional fields:
   characters). This can be a Nostr hex encoded pubkey (not NIP-19) for purposes of sender attribution.
 * `signature` (str) Optionally, this field can contain a signature for the payment, to be able to verify that the
   user who sent it is actually who they claim in the `sender_id` field. If the `sender_id` contains
-  a Nostr public key, this field should contain a Nostr `sig` value as a 64-byte encoded hex string.  
+  a Nostr public key, this field should contain a Nostr `sig` value as a 64-byte encoded hex string.
   For the purpose of generating the Nostr signature, the following data should be serialized:
   [0,`sender_id`,`ts`,1,[],`message`] to conform to the
   [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) specification. The resulting
@@ -150,6 +150,7 @@ Other optional fields:
 * `speed` (str) Speed in which the podcast was playing, in decimal notation at the time the payment was sent. So 0.5
   is half speed and 2 is double speed.
 * `boost_uuid` (str) UUID for the boost/stream/auto payment. If there are several recipients, the same identifier should be sent to all of them.
+* `stream_uuid` (str) UUID for a set of streaming payments from one listening session. Links successive payments for the same item together.
 * `uuid` (str) UUID of a payment sent out to a single recipient.
 * `reply_address` (str) The pubkey of the lightning node that can receive payments for the sender. The node given
   must be capable of receiving keysend payments. If this field contains an "@" symbol, it should
@@ -162,7 +163,7 @@ Other optional fields:
 * `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block because a different feed referenced
   it in a `<podcast:valueTimeSplit>` tag. When that happens, this field will contain the guid of the referencing feed.
 * `remote_item_guid` (str) Sometimes a payment will be sent to an episode's value block because a different feed
-  referenced it in a `<podcast:valueTimeSplit>` tag. When that happens, this field will contain the guid of the 
+  referenced it in a `<podcast:valueTimeSplit>` tag. When that happens, this field will contain the guid of the
   referencing feed's `<item>`.
 
 <br>


### PR DESCRIPTION
Signed-off-by: Brian of London (home imac) <brian@v4v.app>

If we're already adding a `boost_uuid` perhaps we can add a `stream_uuid` which will help stitch all the payments in a single listening session together. Helpful for UI at the display end.

Looking for comments from App devs about whether this is a heavy lift at their end.