### PR TITLE
Followup edits for `<podcast:contentLink>` change

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -37,7 +37,7 @@ document in your XML:
 - [Medium](#medium)
 - [Images](#images)
 - [Live Item](#live-item)
-  - [Content Link](#content-link)
+- [Content Link](#content-link)
 - [Social Interact](#social-interact)
 - [Block](#block)
 - [Txt](#txt)
@@ -1125,8 +1125,8 @@ A bare bones example:
 <br><br><br><br><!-- Tag block -->
 ## Content Link
 `<podcast:contentLink>`<br><br>
-The `contentLink` tag is used to indicate that the content begin delivered by the parent element can be found at an 
-external location instead of, or in addition to, being delivered directly to the tag itself within an app.  In most 
+The `contentLink` tag is used to indicate that the content being delivered by the parent element can be found at an 
+external location instead of, or in addition to, the tag itself within an app.  In most 
 instances it is used as a fallback link for the user to use when the app itself can't handle a certain content 
 delivery directly.
 
@@ -1134,22 +1134,29 @@ For instance, perhaps a podcast feed specifies a `<podcast:liveItem>` to deliver
 may also give a `<podcast:contentLink>` pointing to YouTube and Twitch versions of the live stream as well, just in 
 case the listener uses an app that doesn't fully support live streaming content.
 
-Currently this tag is only indicated for use in the `<podcast:liveItem>` tag.  In the future, its use will be expanded.
-
 ### Parent
-&nbsp; `<podcast:item>` or `<podcast:liveItem>`
+&nbsp; `<item>` or `<podcast:liveItem>`
 
 ### Count
 &nbsp; Multiple
 
 ### Node Value
-The node value is a free form string meant to explain to the user where this content link points and/or the nature 
-of it's purpose.
+The node value is a free-form string meant to explain to the user where this content link points and/or the nature 
+of its purpose.
 
 ### Attributes
  - **href** (required) A string that is the uri pointing to content outside of the application.
 
 ### Examples
+
+(under `<item>`)
+
+```xml
+<podcast:contentLink href="https://www.youtube.com/watch?v=8c7HWZROxD8">Watch this episode on YouTube!</podcast:contentLink>
+```
+
+(under `<podcast:liveItem>`)
+
 ```xml
 <podcast:contentLink href="https://youtube.com/blahblah/livestream">Live on YouTube!</podcast:contentLink>
 ```
@@ -1157,7 +1164,6 @@ of it's purpose.
 ```xml
 <podcast:contentLink href="https://twitter.com/statuses/somepost">Chat on Twitter!</podcast:contentLink>
 ```
-
 
 
 <br><br><br><br><!-- Tag block -->


### PR DESCRIPTION
- Unindent contentLink entry in the TOC
- Fix bogative `<podcast:item>` reference
- Explicit item-level example pointing to a YT video page
- Remove obsolete sentence about limiting to liveItem
- Fix a few other typos and wording issues