### PR TITLE
Fix trailing and missing commas in exampleComplex.json

### DIFF
--- a/chapters/exampleComplex.json
+++ b/chapters/exampleComplex.json
@@ -33,7 +33,7 @@
       "startTime": 4200,
       "title": "Played song by artist",
       "img": "https://i.discogs.com/R-249504-1334592212.jpeg?bucket=discogs-images&fit=contain&format=auto&height=600&quality=90&width=600&signature=wMI9I0mHkbVxkkryQrN1JkkzhwFsrereuom9Lmfa92w%3D",
-      "url": "https://www.discogs.com/Rick-Astley-Never-Gonna-Give-You-Up/master/96559"
+      "url": "https://www.discogs.com/Rick-Astley-Never-Gonna-Give-You-Up/master/96559",
       "value": "<podcast:value type=\"lightning\" method=\"keysend\" suggested=\"0.00000005000\"><podcast:valueRecipient name=\"Performing Artist\" type=\"node\" address=\"03c457fafbc8b91b462ef0b8f61d4fd96577a4b58c18b50e59621fd0f41a8ae1a4\" split=\"100\"/></podcast:value>"
     },  
     {

--- a/chapters/exampleComplex.json
+++ b/chapters/exampleComplex.json
@@ -21,7 +21,7 @@
       "startTime": 410,
       "title": "Namespace",
       "img": "https://example.com/images/namepsace_example.jpg",
-      "url": "https://github.com/Podcastindex-org/podcast-namespace",
+      "url": "https://github.com/Podcastindex-org/podcast-namespace"
     },
     {
       "startTime": 3990,


### PR DESCRIPTION
Because of this, the file couldn't get parsed by https://developer.mozilla.org/en-US/docs/Web/API/Response/json, for example