### PR TITLE
Update socialprotocols.txt

### DIFF
--- a/socialprotocols.txt
+++ b/socialprotocols.txt
@@ -2,7 +2,7 @@ disabled
 activitypub
 twitter
 lightning
-bluesky
+atproto
 hive
 matrix
 nostr


### PR DESCRIPTION
`bluesky` is not a protocol, it should be `atproto`

similarly to how we have `activitypub`, not `mastodon`