### PR TITLE
Improve consistency on trailer examples

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -502,16 +502,16 @@ later be matched up with a `<podcast:season>4<podcast:season>` tag when it is pu
 ```xml
 <podcast:trailer 
         pubdate="Thu, 01 Apr 2021 08:00:00 EST" 
-        url="https://example.org/trailers/teaser" 
+        url="https://example.org/trailers/teaser.mp3" 
         length="12345678" 
-        type="audio/mp3
+        type="audio/mpeg
 ">Coming April 1st, 2021</podcast:trailer>
 ```
 
 ```xml
 <podcast:trailer 
         pubdate="Thu, 01 Apr 2021 08:00:00 EST" 
-        url="https://example.org/trailers/season4teaser" 
+        url="https://example.org/trailers/season4teaser.mp4" 
         length="12345678" 
         type="video/mp4" 
         season="4"


### PR DESCRIPTION
The `url` it's usually used on the spec with the extension

And no other example uses `type=audio/mp3`

I thought to better PR that to ask on a Issue, glad to be corrected if I'm missing something