### PR TITLE
Fix `remote_item_guid` typo

### DIFF
--- a/value/blip-0010.md
+++ b/value/blip-0010.md
@@ -162,7 +162,7 @@ Other optional fields:
 * `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block by way of a `<podcast:valueTimeSplit>`
   tag containing a single `<podcast:remoteItem>` tag. When that happens, this field will contain the `feedGuid` attribute from
   the `<podcast:remoteItem>` tag.
-* `remote_feed_guid` (str) Sometimes a payment will be sent to a feed's value block by way of a `<podcast:valueTimeSplit>`
+* `remote_item_guid` (str) Sometimes a payment will be sent to a feed's value block by way of a `<podcast:valueTimeSplit>`
   tag containing a single `<podcast:remoteItem>` tag having an `itemGuid` attribute. When that happens, this field will contain
   the `itemGuid` attribute from the `<podcast:remoteItem>` tag.
 


### PR DESCRIPTION
The blip-10 doc was showing two `remote_feed_guid` fields when one should be feed and the other should be item.