### PR TITLE
Add back anchors to the ToC

### DIFF
--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -24,33 +24,33 @@ explicitly specified as optional. Anywhere the url of a hyper-text based resourc
 ## Table of Contents
 
 - [Transcript](tags/transcript.md)<a id="transcript" />
-- [Locked](tags/locked.md)
-- [Funding](tags/funding.md)
-- [Chapters](tags/chapters.md)
-- [Soundbite](tags/soundbite.md)
-- [Person](tags/person.md)
-- [Location](tags/location.md)
-- [Season](tags/season.md)
-- [Episode](tags/episode.md)
-- [Trailer](tags/trailer.md)
-- [License](tags/license.md)
-- [Alternate Enclosure](tags/alternate-enclosure.md)
-  - [Source](tags/source.md)
-  - [Integrity](tags/integrity.md)
-- [Guid](tags/guid.md)
-- [Value](tags/value.md)
-  - [Value Recipient](tags/value-recipient.md)
-- [Medium](tags/medium.md)
-- [Images](tags/images.md)
-- [Live Item](tags/live-item.md)
-- [Content Link](tags/content-link.md)
-- [Social Interact](tags/social-interact.md)
-- [Block](tags/block.md)
-- [Txt](tags/txt.md)
-- [Remote Item](tags/remote-item.md)
-- [Podroll](tags/podroll.md)
-- [Update Frequency](tags/update-frequency.md)
-- [Podping](tags/podping.md)
+- [Locked](tags/locked.md)<a id="locked" />
+- [Funding](tags/funding.md)<a id="funding" />
+- [Chapters](tags/chapters.md)<a id="chapters" />
+- [Soundbite](tags/soundbite.md)<a id="soundbite" />
+- [Person](tags/person.md)<a id="person" />
+- [Location](tags/location.md)<a id="location" />
+- [Season](tags/season.md)<a id="season" />
+- [Episode](tags/episode.md)<a id="episode" />
+- [Trailer](tags/trailer.md)<a id="trailer" />
+- [License](tags/license.md)<a id="license" />
+- [Alternate Enclosure](tags/alternate-enclosure.md)<a id="alternate-enclosure" />
+  - [Source](tags/source.md)<a id="source" />
+  - [Integrity](tags/integrity.md)<a id="integrity" />
+- [Guid](tags/guid.md)<a id="guid" />
+- [Value](tags/value.md)<a id="value" />
+  - [Value Recipient](tags/value-recipient.md)<a id="value-recipient" />
+- [Medium](tags/medium.md)<a id="medium" />
+- [Images](tags/images.md)<a id="images" />
+- [Live Item](tags/live-item.md)<a id="live-item" />
+- [Content Link](tags/content-link.md)<a id="content-link" />
+- [Social Interact](tags/social-interact.md)<a id="social-interact" />
+- [Block](tags/block.md)<a id="block" />
+- [Txt](tags/txt.md)<a id="txt" />
+- [Remote Item](tags/remote-item.md)<a id="remote-item" />
+- [Podroll](tags/podroll.md)<a id="podroll" />
+- [Update Frequency](tags/update-frequency.md)<a id="update-frequency" />
+- [Podping](tags/podping.md)<a id="podping" />
 - [Value Time Split](tags/value-time-split.md)<a id="value-time-split" />
-- [Chat](tags/chat.md)
+- [Chat](tags/chat.md)<a id="chat" />
 - [Publisher](tags/publisher.md)<a id="publisher" />

--- a/docs/1.0.md
+++ b/docs/1.0.md
@@ -23,7 +23,7 @@ explicitly specified as optional. Anywhere the url of a hyper-text based resourc
 
 ## Table of Contents
 
-- [Transcript](tags/transcript.md)
+- [Transcript](tags/transcript.md)<a id="transcript" />
 - [Locked](tags/locked.md)
 - [Funding](tags/funding.md)
 - [Chapters](tags/chapters.md)
@@ -51,6 +51,6 @@ explicitly specified as optional. Anywhere the url of a hyper-text based resourc
 - [Podroll](tags/podroll.md)
 - [Update Frequency](tags/update-frequency.md)
 - [Podping](tags/podping.md)
-- [Value Time Split](tags/value-time-split.md)
+- [Value Time Split](tags/value-time-split.md)<a id="value-time-split" />
 - [Chat](tags/chat.md)
-- [Publisher](tags/publisher.md)
+- [Publisher](tags/publisher.md)<a id="publisher" />


### PR DESCRIPTION
Related to this https://github.com/skymethod/livewire-validator/issues/5. There could be more sources pointing to the old anchors. I tested this on my fork and "works"

@theDanielJLewis I hope this doesn't broke your integration. :crossed_fingers: 